### PR TITLE
VWR-458 Fixes to support 3rd party IDPs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ LIBS=$(shell find . -regex "^./lib\/.*\.coffee\$$" | sed s/\.coffee$$/\.js/ | se
 build: $(LIBS)
 
 lib-js/%.js : lib/%.coffee
-	../coffee-script/bin/coffee --bare -c -o $(@D) $(patsubst lib-js/%,lib/%,$(patsubst %.js,%.coffee,$@))
+	set -e ;\
+	coffee_bin_prefix=.. ;\
+	coffee_bin_path=/coffee-script/bin/coffee ;\
+	if [ ! -f "$${coffee_bin_prefix}$${coffee_bin_path}" ]; then coffee_bin_prefix=node_modules; fi ;\
+	$${coffee_bin_prefix}$${coffee_bin_path} --bare -c -o $(@D) $(patsubst lib-js/%,lib/%,$(patsubst %.js,%.coffee,$@))
 
 test-cov:
 	rm -rf lib-js lib-js-cov

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -55,7 +55,10 @@ describe 'saml2', ->
         cert = get_test_file 'test.crt'
         cert2 = get_test_file 'test2.crt'
 
-        metadata = saml2.create_metadata 'https://sp.example.com/metadata.xml', 'https://sp.example.com/assert', cert, cert2
+        assert_endpoint = 'https://sp.example.com/assert'
+        logout_endpoint = 'https://sp.example.com/logout'
+
+        metadata = saml2.create_metadata 'https://sp.example.com/metadata.xml',assert_endpoint, logout_endpoint, cert, cert2
         dom = (new xmldom.DOMParser()).parseFromString metadata
 
         entity_descriptor = dom.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:metadata', 'EntityDescriptor')[0]
@@ -64,13 +67,13 @@ describe 'saml2', ->
 
         assert _(entity_descriptor.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:metadata', 'AssertionConsumerService')).some((assertion) ->
           _(assertion.attributes).some((attr) -> attr.name is 'Binding' and attr.value is 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST') and
-            _(assertion.attributes).some((attr) -> attr.name is 'Location' and attr.value is 'https://sp.example.com/assert'))
+            _(assertion.attributes).some((attr) -> attr.name is 'Location' and attr.value is assert_endpoint))
           , "Expected to find an AssertionConsumerService with POST binding and location 'https://sp.example.com/assert'"
 
         assert _(entity_descriptor.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:metadata', 'SingleLogoutService')).some((assertion) ->
-          _(assertion.attributes).some((attr) -> attr.name is 'Binding' and attr.value is 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect') and
-            _(assertion.attributes).some((attr) -> attr.name is 'Location' and attr.value is 'https://sp.example.com/assert'))
-          , "Expected to find a SingleLogoutService with redirect binding and location 'https://sp.example.com/assert'"
+          _(assertion.attributes).some((attr) -> attr.name is 'Binding' and attr.value is 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST') and
+            _(assertion.attributes).some((attr) -> attr.name is 'Location' and attr.value is logout_endpoint))
+          , "Expected to find a SingleLogoutService with redirect binding and location 'https://sp.example.com/logout'"
 
     describe 'format_pem', ->
       it 'formats an unformatted private key', ->
@@ -84,23 +87,27 @@ describe 'saml2', ->
 
     describe 'sign_request', ->
       it 'correctly signs a get request', ->
-        signed = saml2.sign_request 'TESTMESSAGE', get_test_file("test.pem")
+        uri = new url.URL('https://example.com/assert?qp=123')
+        saml2.sign_request uri, 'TESTMESSAGE', get_test_file("test.pem")
 
         verifier = crypto.createVerify 'RSA-SHA256'
         verifier.update 'SAMLRequest=TESTMESSAGE&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256'
-        assert verifier.verify(get_test_file("test.crt"), signed.Signature, 'base64'), "Signature is not valid"
-        assert.equal signed.SigAlg, 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
-        assert.equal signed.SAMLRequest, 'TESTMESSAGE'
+        assert verifier.verify(get_test_file("test.crt"), uri.searchParams.get('Signature'), 'base64'), "Signature is not valid"
+        assert.equal uri.searchParams.get('SigAlg'), 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+        assert.equal uri.searchParams.get('SAMLRequest'), 'TESTMESSAGE'
+        assert.equal uri.searchParams.get('qp'), '123'
 
       it 'correctly signs a get response with RelayState', ->
-        signed = saml2.sign_request 'TESTMESSAGE', get_test_file("test.pem"), 'TESTSTATE', true
+        uri = new url.URL('https://example.com/assert?qp=123')
+        saml2.sign_request uri, 'TESTMESSAGE', get_test_file("test.pem"), 'TESTSTATE', true
 
         verifier = crypto.createVerify 'RSA-SHA256'
         verifier.update 'SAMLResponse=TESTMESSAGE&RelayState=TESTSTATE&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256'
-        assert verifier.verify(get_test_file("test.crt"), signed.Signature, 'base64'), "Signature is not valid"
-        assert signed.SigAlg, 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
-        assert.equal signed.RelayState, 'TESTSTATE'
-        assert.equal signed.SAMLResponse, 'TESTMESSAGE'
+        assert verifier.verify(get_test_file("test.crt"), uri.searchParams.get('Signature'), 'base64'), "Signature is not valid"
+        assert.equal uri.searchParams.get('SigAlg'), 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+        assert.equal uri.searchParams.get('SAMLResponse'), 'TESTMESSAGE'
+        assert.equal uri.searchParams.get('RelayState'), 'TESTSTATE'
+        assert.equal uri.searchParams.get('qp'), '123'
 
     describe 'check_saml_signature', ->
       it 'accepts signed xml', ->
@@ -173,11 +180,13 @@ describe 'saml2', ->
     describe 'get_name_id', ->
       it 'gets the correct NameID', ->
         name_id = saml2.get_name_id dom_from_test_file('good_assertion.xml')
-        assert.equal name_id, 'tstudent'
+        assert.equal name_id.value, 'tstudent'
+        assert.equal name_id.format, 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
 
       it 'parses assertions with explicit namespaces', ->
         name_id = saml2.get_name_id dom_from_test_file('good_assertion_explicit_namespaces.xml')
-        assert.equal name_id, 'tstudent'
+        assert.equal name_id.value, 'tstudent'
+        assert.equal name_id.format, 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
 
     describe 'get_session_index', ->
       it 'gets the correct session index', ->
@@ -260,6 +269,7 @@ describe 'saml2', ->
           type: 'authn_response'
           user:
             name_id: 'tstudent'
+            name_id_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
             session_index: '_3'
             given_name: 'Test',
             email: 'tstudent@example.com',
@@ -328,6 +338,7 @@ describe 'saml2', ->
           type: 'authn_response'
           user:
             name_id: 'tstudent'
+            name_id_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
             session_index: '_3'
             given_name: 'Test',
             email: 'tstudent@example.com',
@@ -344,7 +355,7 @@ describe 'saml2', ->
               'http://schemas.xmlsoap.org/claims/CommonName': [ 'Test Student' ]
         assert.deepEqual response, expected_response
         # make sure response can be deflated, since redirect requests need to be inflated
-        zlib.deflateRaw new Buffer(response, 'base64'), (err, deflated) =>
+        zlib.deflateRaw Buffer.from(JSON.stringify(response), 'base64'), (err, deflated) =>
           assert not err?, "Got error: #{err}"
           done()
 


### PR DESCRIPTION
- Fix `format_pem` function to remove line breaks from the cert when the function already tries to add them itself (resulting in extra line breaks which make the cert invalid)
- Fix inability to handle assert/logout routes with query parameters
- Fix logic that assumed the SAML namespace always had an explicit prefix
- Update all the unit tests so that they pass again (tests can be run with `make test`)
- Fix Makefile to handle building the library on its own during development

[[VWR-458]](https://arterys.atlassian.net/browse/VWR-458)